### PR TITLE
Remove custom API filters and suggest solution via templates

### DIFF
--- a/awx/api/filters.py
+++ b/awx/api/filters.py
@@ -385,10 +385,6 @@ class FieldLookupBackend(BaseFilterBackend):
             raise ParseError(json.dumps(e.messages, ensure_ascii=False))
 
 
-class HostMetricSummaryMonthlyFieldLookupBackend(FieldLookupBackend):
-    RESERVED_NAMES = ('page', 'page_size', 'format', 'order', 'order_by', 'search', 'type', 'past_months', 'count_disabled', 'no_truncate', 'limit')
-
-
 class OrderByBackend(BaseFilterBackend):
     """
     Filter to apply ordering based on query string parameters.

--- a/awx/api/templates/api/host_metric_detail.md
+++ b/awx/api/templates/api/host_metric_detail.md
@@ -1,0 +1,18 @@
+{% ifmeth GET %}
+# Retrieve {{ model_verbose_name|title|anora }}:
+
+Make GET request to this resource to retrieve a single {{ model_verbose_name }}
+record containing the following fields:
+
+{% include "api/_result_fields_common.md" %}
+{% endifmeth %}
+
+{% ifmeth DELETE %}
+# Delete {{ model_verbose_name|title|anora }}:
+
+Make a DELETE request to this resource to soft-delete this {{ model_verbose_name }}.
+
+A soft deletion will mark the `deleted` field as true and exclude the host
+metric from license calculations.
+This may be undone later if the same hostname is automated again afterwards.
+{% endifmeth %}

--- a/awx/api/templates/api/host_metric_summary_monthly_list.md
+++ b/awx/api/templates/api/host_metric_summary_monthly_list.md
@@ -1,0 +1,12 @@
+# Intended Use Case
+
+To get summaries from a certain day or earlier, you can filter this
+endpoint in the following way.
+
+    ?date__gte=2023-01-01
+
+This will return summaries that were produced on that date or later.
+These host metric monthly summaries should be automatically produced
+by a background task that runs once each month.
+
+{% include "api/list_api_view.md" %}

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -122,7 +122,6 @@ from awx.api.views.mixin import (
     UnifiedJobDeletionMixin,
     NoTruncateMixin,
 )
-from awx.api.filters import HostMetricSummaryMonthlyFieldLookupBackend
 from awx.api.pagination import UnifiedJobEventPagination
 from awx.main.utils import set_environ
 
@@ -1561,29 +1560,9 @@ class HostMetricSummaryMonthlyList(ListAPIView):
     serializer_class = serializers.HostMetricSummaryMonthlySerializer
     permission_classes = (IsSystemAdminOrAuditor,)
     search_fields = ('date',)
-    filter_backends = [HostMetricSummaryMonthlyFieldLookupBackend]
 
     def get_queryset(self):
-        queryset = self.model.objects.all()
-        past_months = self.request.query_params.get('past_months', None)
-        date_from = self._get_date_from(past_months)
-
-        queryset = queryset.filter(date__gte=date_from)
-        return queryset
-
-    @staticmethod
-    def _get_date_from(past_months, default=12, maximum=36):
-        try:
-            months_ago = int(past_months or default)
-        except ValueError:
-            months_ago = default
-        months_ago = min(months_ago, maximum)
-        months_ago = max(months_ago, 1)
-
-        date_from = datetime.date.today() - dateutil.relativedelta.relativedelta(months=months_ago)
-        # Set to beginning of the month
-        date_from = date_from.replace(day=1).isoformat()
-        return date_from
+        return self.model.objects.all()
 
 
 class HostList(HostRelatedSearchMixin, ListCreateAPIView):


### PR DESCRIPTION
##### SUMMARY
Introducing custom filter views to allow special query parameters is something we would like to avoid if possible. Looking at the case of `past_months`, I realize that I would really strongly prefer to solve the problem with documention.

This adds templates for the API docs, it appears when clicking the "?" in the API browser:

![Screenshot from 2023-02-23 14-44-23](https://user-images.githubusercontent.com/1385596/221013547-0e115416-512c-49fe-ac8d-7591332d0d86.png)

This might not be 100% as good as the field which computes time from the current day, but it's much more consistent and maintainable.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

