### PR TITLE
Use a datetime from 1970 for type consistency

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -392,7 +392,7 @@ def cleanup_host_metrics():
 def is_run_threshold_reached(setting, threshold_seconds):
     from rest_framework.fields import DateTimeField
 
-    last_time = DateTimeField().to_internal_value(setting.value) if setting and setting.value else 0
+    last_time = DateTimeField().to_internal_value(setting.value) if setting and setting.value else DateTimeField().to_internal_value('1970-01-01')
 
     return (now() - last_time).total_seconds() > threshold_seconds
 


### PR DESCRIPTION
##### SUMMARY
I was switching branches to test this and ran into the error:

```
tools_awx_1 | awx-dispatcher stderr | 2023-07-01 02:45:58,971 ERROR    [84ee472b] awx.main.dispatch Worker failed to run task awx.main.tasks.system.gather_analytics(*[], **{}
tools_awx_1 | awx-dispatcher stderr | Traceback (most recent call last):
tools_awx_1 | awx-dispatcher stderr |   File "/awx_devel/awx/main/dispatch/worker/task.py", line 103, in perform_work
tools_awx_1 | awx-dispatcher stderr |     result = self.run_callable(body)
tools_awx_1 | awx-dispatcher stderr |   File "/awx_devel/awx/main/dispatch/worker/task.py", line 78, in run_callable
tools_awx_1 | awx-dispatcher stderr |     return _call(*args, **kwargs)
tools_awx_1 | awx-dispatcher stderr |   File "/awx_devel/awx/main/tasks/system.py", line 320, in gather_analytics
tools_awx_1 | awx-dispatcher stderr |     if is_run_threshold_reached(Setting.objects.filter(key='AUTOMATION_ANALYTICS_LAST_GATHER').first(), settings.AUTOMATION_ANALYTICS_GATHER_INTERVAL):
tools_awx_1 | awx-dispatcher stderr |   File "/awx_devel/awx/main/tasks/system.py", line 397, in is_run_threshold_reached
tools_awx_1 | awx-dispatcher stderr |     return (now() - last_time).total_seconds() > threshold_seconds
tools_awx_1 | awx-dispatcher stderr | TypeError: unsupported operand type(s) for -: 'datetime.datetime' and 'int'
```

This wasn't a problem with the new monthly host summary task, but with the older host metrics cleanup task. This explains why I didn't see this until recently, because we probably don't have good integration testing for that.

To reproduce this, it was fairly easy on a new install with a new database:

```
from awx.main.tasks.system import cleanup_host_metrics

cleanup_host_metrics()
```

That generates the traceback seen above before this change. After this change, it produces:

```
In [2]: cleanup_host_metrics()
2023-07-05 13:29:30,992 INFO     [-] awx.main.tasks.system Executing cleanup_host_metrics
2023-07-05 13:29:30,993 INFO     [-] awx.main.models.inventory cleanup_host_metrics: soft-deleting records last automated before 2022-07-05 13:29:30.993179+00:00
2023-07-05 13:29:31,058 INFO     [-] awx.main.tasks.system Finished cleanup_host_metrics
```

This matches expectations, because the question being asked is "when was the last time you ran?" and then the answer given to that question is "1970", and then the conclusion is "oh, that was a long time ago, so we should run now"

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

